### PR TITLE
Update example to use ES6 syntax

### DIFF
--- a/docs/using-nodejs.md
+++ b/docs/using-nodejs.md
@@ -11,17 +11,17 @@ sidebar_label: In NodeJS
 ## Example nodejs application
 
 ```
-var jsonata = require("jsonata");
+const jsonata = require("jsonata");
 
-var data = {
+const data = {
   example: [
     {value: 4},
     {value: 7},
     {value: 13}
   ]
 };
-var expression = jsonata("$sum(example.value)");
-var result = expression.evaluate(data);  // returns 24
+let expression = jsonata("$sum(example.value)");
+let result = expression.evaluate(data);  // returns 24
 ```
 
 ## ES5 runtimes


### PR DESCRIPTION
A small update so that the example nodeJS application uses ES6 syntax (now `jsonata` is node v6+).